### PR TITLE
Remove "RUN go get" from DockerFile in Go-Postgres container

### DIFF
--- a/containers/go-postgres/.devcontainer/Dockerfile
+++ b/containers/go-postgres/.devcontainer/Dockerfile
@@ -10,10 +10,10 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
-# [Optional] Add more packages to the below lines to use go get to install anything else you need
-USER vscode
-RUN go get -x github.com/lib/pq
-USER root
+# [Optional] Uncomment the next lines to use go get to install anything else you need
+# USER vscode
+# RUN go get -x <your-dependency-or-tool>
+# USER root
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/go-postgres/test-project/go.mod
+++ b/containers/go-postgres/test-project/go.mod
@@ -1,0 +1,5 @@
+module test-project
+
+go 1.17
+
+require github.com/lib/pq v1.10.4

--- a/containers/go-postgres/test-project/go.sum
+++ b/containers/go-postgres/test-project/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
+github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=


### PR DESCRIPTION
Changes in reference to bug [AzDO 23066](https://dev.azure.com/dwrdev/HackOverflowFDX/_workitems/edit/23066)
---
Result of spike-task: using `go mod` commands was straightforward to create go.mod and go.sum files that enable `go run` commands to correctly download and use dependencies + references.

Impact: we de-coupled the go-module(s) "dependency declaration" from the image itself, which is consistent with other containers (i.e. see python containers using environment.yml in DockerFile)

Estimate for fix: a local PR is ready, so mainly review time & confirming approach w/ Chuck