### PR TITLE
Add vcpkg context from base cpp image to the cpp-mariadb container

### DIFF
--- a/containers/cpp-mariadb/.devcontainer/Dockerfile
+++ b/containers/cpp-mariadb/.devcontainer/Dockerfile
@@ -9,3 +9,21 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 COPY ./install-mariadb.sh /
 RUN chmod +x /install-mariadb.sh && ./install-mariadb.sh
+
+# [Optional] Install CMake version different from what base image has already installed. 
+# CMake reinstall choices: none, 3.21.5, 3.22.2, or versions from https://cmake.org/download/
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
+
+# Optionally install the cmake for vcpkg
+COPY ./reinstall-cmake.sh /tmp/
+RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
+        /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    fi \
+    && rm -f /tmp/reinstall-cmake.sh
+
+# [Optional] Uncomment this section to install additional vcpkg ports.
+# RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/containers/cpp-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/cpp-mariadb/.devcontainer/docker-compose.yml
@@ -12,7 +12,6 @@ services:
         # Update 'VARIANT' to pick a version of CPP
         # See the README for more information on available versions.
         VARIANT: debian-11
-        REINSTALL_CMAKE_VERSION_FROM_SOURCE: "none"
     env_file:
       - .env
 

--- a/containers/cpp-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/cpp-mariadb/.devcontainer/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         # Update 'VARIANT' to pick a version of CPP
         # See the README for more information on available versions.
         VARIANT: debian-11
+        REINSTALL_CMAKE_VERSION_FROM_SOURCE: "none"
     env_file:
       - .env
 

--- a/containers/cpp-mariadb/.devcontainer/reinstall-cmake.sh
+++ b/containers/cpp-mariadb/.devcontainer/reinstall-cmake.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+set -e
+
+CMAKE_VERSION=${1:-"none"}
+
+if [ "${CMAKE_VERSION}" = "none" ]; then
+    echo "No CMake version specified, skipping CMake reinstallation"
+    exit 0
+fi
+
+# Cleanup temporary directory and associated files when exiting the script.
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    if [[ -n "${TMP_DIR}" ]]; then
+        echo "Executing cleanup of tmp files"
+        rm -Rf "${TMP_DIR}"
+    fi
+    exit $EXIT_CODE
+}
+trap cleanup EXIT
+
+
+echo "Installing CMake..."
+apt-get -y purge --auto-remove cmake
+mkdir -p /opt/cmake
+
+architecture=$(dpkg --print-architecture)
+case "${architecture}" in
+    arm64)
+        ARCH=aarch64 ;;
+    amd64)
+        ARCH=x86_64 ;;
+    *)
+        echo "Unsupported architecture ${architecture}."
+        exit 1
+        ;;
+esac
+
+CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
+CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
+TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
+
+echo "${TMP_DIR}"
+cd "${TMP_DIR}"
+
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_BINARY_NAME}" -O
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_CHECKSUM_NAME}" -O
+
+sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
+sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
+
+ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake

--- a/containers/cpp-mariadb/README.md
+++ b/containers/cpp-mariadb/README.md
@@ -32,7 +32,29 @@ build:
       VARIANT: debian-11
 ```
 
-Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
+Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, a set of common dependencies for development, and [Vcpkg](https://github.com/microsoft/vcpkg) a cross-platform package manager for C++.
+
+### Using Vcpkg
+This dev container and its associated image includes a clone of the [`Vcpkg`](https://github.com/microsoft/vcpkg) repo for library packages, and a bootstrapped instance of the [Vcpkg-tool](https://github.com/microsoft/vcpkg-tool) itself.
+
+The minimum version of `cmake` required to install packages is higher than the version available in the main package repositories for Debian (<=11) and Ubuntu (<=21.10).  `Vcpkg` will download a compatible version of `cmake` for its own use if that is the case (on x86_64 architectures), however you can opt to reinstall a different version of `cmake` globally by adding `REINSTALL_CMAKE_VERSION_FROM_SOURCE: <VERSION>` to build args in `.devcontainer/docker-compose.yml`. This will install `cmake` from its github releases. For example:
+
+```yaml
+args:
+  VARIANT: debian-11
+  REINSTALL_CMAKE_VERSION_FROM_SOURCE: "3.21.5" # Set to "none" to skip re-install of cmake
+```
+
+Most additional library packages installed using Vcpkg will be downloaded from their [official distribution locations](https://github.com/microsoft/vcpkg#security). To configure Vcpkg in this container to access an alternate registry, more information can be found here: [Registries: Bring your own libraries to vcpkg](https://devblogs.microsoft.com/cppblog/registries-bring-your-own-libraries-to-vcpkg/).
+
+To update the available library packages, pull the latest from the git repository using the following command in the terminal:
+
+```sh
+cd "${VCPKG_ROOT}"
+git pull --ff-only
+```
+
+> Note: Please review the [Vcpkg license details](https://github.com/microsoft/vcpkg#license) to better understand its own license and additional license information pertaining to library packages and supported ports.
 
 ### Adding the definition to a project or codespace
 

--- a/containers/cpp-mariadb/README.md
+++ b/containers/cpp-mariadb/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Docker Compose |
 | *Available image variants* | [See cpp definition](../cpp). |
-| *Supported architecture(s)* | x86-64, aarch64/arm64 for `bullseye`, `stretch`, `bionic`, and `hirsute` variants |
+| *Supported architecture(s)* | x86-64 for `bullseye`, `stretch`, `bionic`, and `hirsute` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian, Ubuntu |

--- a/containers/cpp-mariadb/test-project/test.sh
+++ b/containers/cpp-mariadb/test-project/test.sh
@@ -22,6 +22,7 @@ if [ "$(dpkg --print-architecture)" = "amd64" ] || [[ ! "${VCPKG_UNSUPPORTED_ARM
     VCPKG_FORCE_SYSTEM_BINARIES=1 check "vcpkg-from-root" ${VCPKG_ROOT}/vcpkg --version
     VCPKG_FORCE_SYSTEM_BINARIES=1 check "vcpkg-from-bin" vcpkg --version
 fi 
+checkOSPackages "tools-for-mariadb" libmariadb3 libmariadb-dev
 check "g++"  g++ -g main.cpp -o main.out -lmariadbcpp
 check "main.out" ./main.out
 rm main.out

--- a/containers/cpp-mariadb/test-project/test.sh
+++ b/containers/cpp-mariadb/test-project/test.sh
@@ -14,7 +14,7 @@ checkExtension "ms-vscode.cpptools"
 checkExtension "ms-vscode.cmake-tools"
 checkExtension "ms-vscode.cpptools-extension-pack"
 checkOSPackages "command-line-tools" build-essential cmake cppcheck valgrind clang lldb llvm gdb
-checkOSPackages "tools-for-vcpkg" tar curl zip unzip pkg-config bash-completion
+checkOSPackages "tools-for-vcpkg" tar curl zip unzip pkg-config bash-completion ninja-build
 VCPKG_UNSUPPORTED_ARM64_VERSION_CODENAMES="stretch bionic"
 if [ "$(dpkg --print-architecture)" = "amd64" ] || [[ ! "${VCPKG_UNSUPPORTED_ARM64_VERSION_CODENAMES}" = *"${VERSION_CODENAME}"* ]]; then
     check "VCPKG_ROOT" [ -d "${VCPKG_ROOT}" ]

--- a/containers/cpp-mariadb/test-project/test.sh
+++ b/containers/cpp-mariadb/test-project/test.sh
@@ -6,11 +6,22 @@ source test-utils.sh vscode
 # Run common tests
 checkCommon
 
+# Help determine distro
+. /etc/os-release 
+
 # Run definition specific tests
 checkExtension "ms-vscode.cpptools"
 checkExtension "ms-vscode.cmake-tools"
 checkExtension "ms-vscode.cpptools-extension-pack"
 checkOSPackages "command-line-tools" build-essential cmake cppcheck valgrind clang lldb llvm gdb
+checkOSPackages "tools-for-vcpkg" tar curl zip unzip pkg-config bash-completion
+VCPKG_UNSUPPORTED_ARM64_VERSION_CODENAMES="stretch bionic"
+if [ "$(dpkg --print-architecture)" = "amd64" ] || [[ ! "${VCPKG_UNSUPPORTED_ARM64_VERSION_CODENAMES}" = *"${VERSION_CODENAME}"* ]]; then
+    check "VCPKG_ROOT" [ -d "${VCPKG_ROOT}" ]
+    check "VCPKG_DOWNLOAD" [ -d "${VCPKG_DOWNLOADS}" ]
+    VCPKG_FORCE_SYSTEM_BINARIES=1 check "vcpkg-from-root" ${VCPKG_ROOT}/vcpkg --version
+    VCPKG_FORCE_SYSTEM_BINARIES=1 check "vcpkg-from-bin" vcpkg --version
+fi 
 check "g++"  g++ -g main.cpp -o main.out -lmariadbcpp
 check "main.out" ./main.out
 rm main.out

--- a/containers/cpp/test-project/test.sh
+++ b/containers/cpp/test-project/test.sh
@@ -12,7 +12,7 @@ checkCommon
 # Run definition specific tests
 checkExtension "ms-vscode.cpptools"
 checkOSPackages "command-line-tools" build-essential cmake cppcheck valgrind clang lldb llvm gdb
-checkOSPackages "tools-for-vcpkg" tar curl zip unzip pkg-config bash-completion
+checkOSPackages "tools-for-vcpkg" tar curl zip unzip pkg-config bash-completion ninja-build
 VCPKG_UNSUPPORTED_ARM64_VERSION_CODENAMES="stretch bionic"
 if [ "$(dpkg --print-architecture)" = "amd64" ] || [[ ! "${VCPKG_UNSUPPORTED_ARM64_VERSION_CODENAMES}" = *"${VERSION_CODENAME}"* ]]; then
     check "VCPKG_ROOT" [ -d "${VCPKG_ROOT}" ]


### PR DESCRIPTION
> NOTES for this 'private' PR. The real 'public' PR against [msft-main](https://github.com/microsoft/vscode-dev-containers) will use the [full template](https://microsoft.sharepoint.com/teams/route66zakim/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x0120004E9AD3C7FA91164E9F3004700F8EA1AC&id=%2Fteams%2Froute66zakim%2FShared%20Documents%2FGeneral%2Fpull%2Drequest%2Dtemplate%2Emd&parent=%2Fteams%2Froute66zakim%2FShared%20Documents%2FGeneral&p=5): 
> - Local testing required making the Dockerfile use a **dev** base image as starting point image, i.e. `mcr.microsoft.com/vscode/devcontainers/cpp:dev-debian-11`, since the "cpp w/ vcpkg" images are not published fully (yet)
> - Changes to `Dockerfile`, `test.sh`  are taken from the containers/cpp copy verbatim (except for 1 additional test).
> - File `reinstall-cmake.sh` is verbatim from containers/cpp
> - The updates to README.md have a couple tweaks when compared to the containers/cpp version, such as refer to `docker-compose.yml` rather than `devcontainer.json` for `REINSTALL_CMAKE_VERSION_FROM_SOURCE` sample